### PR TITLE
wait for installation of kube-system & cert-manager & nginx-ingress

### DIFF
--- a/tasks/cert-manager.yml
+++ b/tasks/cert-manager.yml
@@ -16,3 +16,9 @@
     src: /root/install/cert-manager.yaml
   tags:
     - cert-manager_install
+
+- include: wait2complete.yml
+  vars:
+    item: cert-manager
+  tags:
+    - cert-manager-wait

--- a/tasks/cert-manager.yml
+++ b/tasks/cert-manager.yml
@@ -19,6 +19,6 @@
 
 - include: wait2complete.yml
   vars:
-    item: cert-manager
+    namespace: cert-manager
   tags:
     - cert-manager-wait

--- a/tasks/ingress-nginx.yml
+++ b/tasks/ingress-nginx.yml
@@ -48,3 +48,9 @@
     patch_check.stdout != '443'
   tags:
     - ingress-nginx_patch
+
+# - include: wait2complete.yml
+#   vars:
+#     item: ingress-nginx
+#   tags:
+#     - ingress-nginx_wait

--- a/tasks/ingress-nginx.yml
+++ b/tasks/ingress-nginx.yml
@@ -49,8 +49,9 @@
   tags:
     - ingress-nginx_patch
 
-# - include: wait2complete.yml
-#   vars:
-#     item: ingress-nginx
-#   tags:
-#     - ingress-nginx_wait
+- include: wait2complete.yml
+  vars:
+    pod_name: ingress-nginx-controller
+    namespace: ingress-nginx
+  tags:
+    - ingress-nginx_wait

--- a/tasks/rke.yml
+++ b/tasks/rke.yml
@@ -106,10 +106,20 @@
     namespace: default
     state: present
     src: /etc/ansible/roles/rke2/files/networkpolicy.yaml
+  tags:
+    - rke2_network-policy
 
 - name: wait to complete instalation of rke2
   include: wait2complete.yml
   vars:
-    item: kube-system
+    pod_name: "kube-scheduler-{{ ansible_hostname }}"
+    namespace: kube-system
+  tags:
+    kube-system-wait
+
+- name: wait to complete instalation of rke2
+  include: wait2complete.yml
+  vars:
+    namespace: kube-system
   tags:
     kube-system-wait

--- a/tasks/rke.yml
+++ b/tasks/rke.yml
@@ -109,7 +109,7 @@
   tags:
     - rke2_network-policy
 
-- name: wait to complete instalation of rke2
+- name: wait to start of instalation of rke2
   include: wait2complete.yml
   vars:
     pod_name: "kube-scheduler-{{ ansible_hostname }}"

--- a/tasks/rke.yml
+++ b/tasks/rke.yml
@@ -106,3 +106,10 @@
     namespace: default
     state: present
     src: /etc/ansible/roles/rke2/files/networkpolicy.yaml
+
+- name: wait to complete instalation of rke2
+  include: wait2complete.yml
+  vars:
+    item: kube-system
+  tags:
+    kube-system-wait

--- a/tasks/wait2complete.yml
+++ b/tasks/wait2complete.yml
@@ -1,9 +1,20 @@
 ---
-- name: "wait untill instalation of {{ item }} is complete (max 10min, delay=5s)"
+- name: "wait untill {{ pod_name }} in {{ namespace }} is Running (max 10min, delay=5s)"
   shell:
-    cmd: "/var/lib/rancher/rke2/bin/kubectl -n {{ item }} get pods -o json |jq '.items[].status.phase' | grep -v Succeeded | sort -u"
+    cmd: "test `/var/lib/rancher/rke2/bin/kubectl -n {{ namespace }} get pod  |grep {{ pod_name }} | grep Running | wc -l` -ge 1"
   register: prq
-  until: prq.stdout == '"Running"'
-  retries: 300
+  until: prq.rc == 0
+  retries: 120 # 10*60/5
   delay: 5
   changed_when: false
+  when: pod_name is defined
+
+- name: "wait untill all pods in namespace {{ namespace }} are Running (max 10min, delay=5s)"
+  shell:
+    cmd: "/var/lib/rancher/rke2/bin/kubectl -n {{ namespace }} get pod -o json |jq '.items[].status.phase' | grep -v Succeeded | sort -u"
+  register: prq
+  until: prq.stdout == '"Running"'
+  retries: 120
+  delay: 5
+  changed_when: false
+  when: not pod_name is defined

--- a/tasks/wait2complete.yml
+++ b/tasks/wait2complete.yml
@@ -1,0 +1,9 @@
+---
+- name: "wait untill instalation of {{ item }} is complete (max 10min, delay=5s)"
+  shell:
+    cmd: "/var/lib/rancher/rke2/bin/kubectl -n {{ item }} get pods -o json |jq '.items[].status.phase' | grep -v Succeeded | sort -u"
+  register: prq
+  until: prq.stdout == '"Running"'
+  retries: 300
+  delay: 5
+  changed_when: false


### PR DESCRIPTION
Patch for waiting until installation of kube-system & cert-manager & ingress-nginx is complete. Equivalent code was part of czertainly.yml sub/task of host-config. It has to be independent - https://github.com/3KeyCompany/CZERTAINLY-Appliance/issues/5