### PR TITLE
disable instalation of ingress-nginx by default

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,7 @@
 
 - name: install ingress-nginx
   include: ingress-nginx.yml
+  when: rke2_install_ingress_nginx
   tags: ingress-nginx
 
 - name: install cert-manager

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,4 @@
 ---
 # vars file for rke2
+
+rke2_install_ingress_nginx: false


### PR DESCRIPTION
Ingress-nginx is part of RKE2 it isn't needed to install it. Disabling code for now, removing it maybe later.

closes #12 