### PR TITLE
set corect permisons

### DIFF
--- a/tasks/rke2.yml
+++ b/tasks/rke2.yml
@@ -111,7 +111,7 @@
     dest: "{{ item.dir }}/config"
     owner: "{{ item.owner }}"
     group: "{{ item.group }}"
-    mode: "0400"
+    mode: "0600"
   with_items: "{{ kube_cfg_dir }}"
   tags:
     - kube_config


### PR DESCRIPTION
needed for setting default namespace=czertainly

part of: https://github.com/CZERTAINLY/CZERTAINLY-Appliance-Tools/issues/103